### PR TITLE
fix: 修复 webcomponents polyfill 加载问题

### DIFF
--- a/packages/web-extension/manifest.json
+++ b/packages/web-extension/manifest.json
@@ -22,7 +22,6 @@
     {
       "matches": ["https://juejin.cn/**"],
       "js": [
-        "./node_modules/@webcomponents/webcomponentsjs/webcomponents-bundle.js",
         "src/content-scripts/home/index.ts",
         "src/content-scripts/user/index.ts",
         "src/content-scripts/pins/index.ts"

--- a/packages/web-extension/src/content-scripts/home/components/index.ts
+++ b/packages/web-extension/src/content-scripts/home/components/index.ts
@@ -1,5 +1,6 @@
 import { defineCustomElement } from 'vue'
 import ClientActivityFloating from './ClientActivityFloating.ce.vue'
+import '@webcomponents/webcomponentsjs/webcomponents-bundle'
 
 const CustomActivityFloating = defineCustomElement(ClientActivityFloating)
 

--- a/packages/web-extension/src/content-scripts/pins/components/index.ts
+++ b/packages/web-extension/src/content-scripts/pins/components/index.ts
@@ -1,5 +1,6 @@
 import { defineCustomElement } from 'vue'
 import ClientPinActivities from './ClientPinActivities.ce.vue'
+import '@webcomponents/webcomponentsjs/webcomponents-bundle'
 
 const CustomPinActivities = defineCustomElement(ClientPinActivities)
 

--- a/packages/web-extension/src/content-scripts/user/index.ts
+++ b/packages/web-extension/src/content-scripts/user/index.ts
@@ -3,6 +3,7 @@ import { getCurrentUserId } from "../utils/getInformation";
 import onRouteChange from "../utils/onRouteChange";
 import { CustomJoinedArticleActivity, CustomUserTagRadar, CustomUserTrace, register } from "./components";
 import { initUserArticleList } from "@/core/clientRequests/initUserArticles";
+import '@webcomponents/webcomponentsjs/webcomponents-bundle'
 
 register();
 main();


### PR DESCRIPTION
当前版本的插件在访问掘金主页的时候，可能会偶现 webcomponents polyfill 无法加载的问题

原因在于 `@crxjs/vite-plugin` 打包 `content_scripts` 的时候，产物将以 `async` 的方式加载，可能会导致 polyfill 还没加载完就开始加载业务代码

```js
(function () {
  'use strict';

  (async () => {
    await import(
      /* @vite-ignore */
      chrome.runtime.getURL("assets/index.ts.7bace314.js")
    );
  })().catch(console.error);

})();
```

同时 `@crxjs/vite-plugin` 的作者也提到对于 unbundle script 的支持还在进行中: https://github.com/crxjs/chrome-extension-tools/issues/441

webcomponents polyfill 似乎支持 esm 的加载方式，因此在每个模块的注册 customElements 的位置 import 该 polyfill

**有待进一步验证修复的正确性**